### PR TITLE
Changed jupyter port inside container to 9987 (same as host port)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ RUN set -x && \
 
 ADD keras.json /root/.keras/keras.json
 
-EXPOSE 8888
+EXPOSE 9987
 EXPOSE 6006
+
+CMD ["/run_jupyter.sh", "--allow-root", "--port=9987"]

--- a/run_tensorflow.sh
+++ b/run_tensorflow.sh
@@ -4,4 +4,4 @@ cd ${PROJECT_ROOT}
 
 docker build -t kapa ./
 
-docker run -it -p 9987:8888 -p 6006:6006 -v ${PWD}:/notebooks kapa $1
+docker run -it -p 9987:9987 -p 6006:6006 -v ${PWD}:/notebooks kapa $1


### PR DESCRIPTION
Message now shows correct port.
```
    Copy/paste this URL into your browser when you connect for the first time,
    to login with a token:
        http://localhost:9987/?token=...

```